### PR TITLE
Adhere to a challenge's pending status

### DIFF
--- a/acme_linode_objectstorage/__main__.py
+++ b/acme_linode_objectstorage/__main__.py
@@ -126,7 +126,7 @@ def main():
                 # Respond to the challenge
                 try:
                     challenge.respond()
-                    challenge.poll_until_not({'processing'})
+                    challenge.poll_until_not({'processing', 'pending'})
                 except requests.HTTPError as e:
                     print(f'ERROR: Responding to challenge failed: {e.response.text}', file=sys.stderr)
                     return 1


### PR DESCRIPTION
Currently, the status of an active challenge is polled until it is not `processing` anymore.

According to https://datatracker.ietf.org/doc/html/draft-ietf-acme-acme-07 (and also according to personal experience) the server can leave a challenge in the state `pending`.

This pull request takes `pending` into account when waiting for a server to process a challenge. Otherwise the program might exit with `ERROR: Challenge unsuccessful: pending`.