### PR TITLE
Add log-level argument

### DIFF
--- a/acme_linode_objectstorage/__main__.py
+++ b/acme_linode_objectstorage/__main__.py
@@ -25,15 +25,21 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('-k', '--account-key', required=True)
     parser.add_argument('-C', '--cluster', default='us-east-1')
+    parser.add_argument('-v', '--verbose', action='store_true')
     parser.add_argument('--agree-to-terms-of-service', action='store_true')
     parser.add_argument('domain')
     return parser.parse_args()
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG)
-
     args = parse_args()
+
+    if args.verbose:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+
+    logging.basicConfig(level=level)
 
     if not LINODE_TOKEN:
         print('ERROR: LINODE_TOKEN environment variable not set', file=sys.stderr)


### PR DESCRIPTION
I use acme-linode-objectstorage in a GitHub workflow and the default logging level of DEBUG  leaks keys in the GitHub action logs. I've added an option to set the logging level, and it defaults to INFO.